### PR TITLE
Fix type mismatch in Windows IPC interface

### DIFF
--- a/windows/daemon_cl/windows_hal.cpp
+++ b/windows/daemon_cl/windows_hal.cpp
@@ -352,7 +352,7 @@ bool WindowsNamedPipeIPC::update_network_interface(
 	uint8_t  clock_identity[],
 	uint8_t  priority1,
 	uint8_t  clock_class,
-	int16_t  offset_scaled_log_variance,
+        uint16_t offset_scaled_log_variance,
 	uint8_t  clock_accuracy,
 	uint8_t  priority2,
 	uint8_t  domain_number,

--- a/windows/daemon_cl/windows_hal.hpp
+++ b/windows/daemon_cl/windows_hal.hpp
@@ -961,7 +961,7 @@ public:
 		uint8_t  clock_identity[],
 		uint8_t  priority1,
 		uint8_t  clock_class,
-		int16_t  offset_scaled_log_variance,
+                uint16_t offset_scaled_log_variance,
 		uint8_t  clock_accuracy,
 		uint8_t  priority2,
 		uint8_t  domain_number,

--- a/windows/daemon_cl/windows_ipc.hpp
+++ b/windows/daemon_cl/windows_ipc.hpp
@@ -177,7 +177,7 @@ class Offset {
         uint8_t  clock_identity[PTP_CLOCK_IDENTITY_LENGTH];     //!< The clock identity of the interface
         uint8_t  priority1;                                     //!< The priority1 field of the grandmaster functionality of the interface, or 0xFF if not supported
         uint8_t  clock_class;                                   //!< The clockClass field of the grandmaster functionality of the interface, or 0xFF if not supported
-        int16_t  offset_scaled_log_variance;                    //!< The offsetScaledLogVariance field of the grandmaster functionality of the interface, or 0x0000 if not supported
+        uint16_t offset_scaled_log_variance;                    //!< The offsetScaledLogVariance field of the grandmaster functionality of the interface, or 0x0000 if not supported
         uint8_t  clock_accuracy;                                //!< The clockAccuracy field of the grandmaster functionality of the interface, or 0xFF if not supported
         uint8_t  priority2;                                     //!< The priority2 field of the grandmaster functionality of the interface, or 0xFF if not supported
         uint8_t  domain_number;                                 //!< The domainNumber field of the grandmaster functionality of the interface, or 0 if not supported


### PR DESCRIPTION
## Summary
- use `uint16_t` for offset variance fields
- adjust Windows HAL interface to use unsigned type

## Testing
- `cmake ..`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68517cdb6fa88322924add6f206c4c0e