### PR TITLE
Fix deprecated pthread_yield usage

### DIFF
--- a/linux/src/linux_hal_common.cpp
+++ b/linux/src/linux_hal_common.cpp
@@ -37,6 +37,7 @@
 #include <ether_port.hpp>
 
 #include <pthread.h>
+#include <sched.h>
 #include <linux_ipc.hpp>
 
 #include <sys/mman.h>
@@ -646,7 +647,7 @@ bool TicketingLock::lock( bool *got ) {
 		goto done;
 	}
 
-	if( yield ) pthread_yield();
+       if( yield ) sched_yield();
 
  done:
 	return ret;


### PR DESCRIPTION
## Summary
- include `<sched.h>` and use `sched_yield()`
- rebuild to clear deprecation warning

## Testing
- `make -C linux/build clean all`

------
https://chatgpt.com/codex/tasks/task_e_6851849c45cc8322bdae662edc9e4078