### PR TITLE
Fix PTP device path formatting

### DIFF
--- a/linux/src/linux_hal_common.hpp
+++ b/linux/src/linux_hal_common.hpp
@@ -51,8 +51,7 @@
 
 #define ONE_WAY_PHY_DELAY 400	/*!< One way phy delay. TX or RX phy delay default value*/
 #define P8021AS_MULTICAST "\x01\x80\xC2\x00\x00\x0E"	/*!< Default multicast address*/
-#define PTP_DEVICE "/dev/ptpXX"			/*!< Default PTP device */
-#define PTP_DEVICE_IDX_OFFS 8			/*!< PTP device index offset*/
+#define PTP_DEVICE "/dev/ptp"			/*!< Default PTP device prefix */
 #define CLOCKFD 3						/*!< Clock file descriptor */
 #define FD_TO_CLOCKID(fd)       ((~(clockid_t) (fd) << 3) | CLOCKFD)	/*!< Converts an FD to CLOCKID */
 struct timespec;

--- a/linux/src/linux_hal_generic.cpp
+++ b/linux/src/linux_hal_generic.cpp
@@ -224,8 +224,8 @@ bool LinuxTimestamperGeneric::Adjust( void *tmx ) const {
 bool LinuxTimestamperGeneric::HWTimestamper_init
 ( InterfaceLabel *iface_label, OSNetworkInterface *iface ) {
 	cross_stamp_good = false;
-	int phc_index;
-	char ptp_device[] = PTP_DEVICE;
+        int phc_index;
+        char ptp_device[32];
 #ifdef PTP_HW_CROSSTSTAMP
 	struct ptp_clock_caps ptp_capability;
 #endif
@@ -240,9 +240,7 @@ bool LinuxTimestamperGeneric::HWTimestamper_init
 		return false;
 	}
 
-	snprintf
-		( ptp_device+PTP_DEVICE_IDX_OFFS,
-		  sizeof(ptp_device)-PTP_DEVICE_IDX_OFFS, "%d", phc_index );
+        snprintf( ptp_device, sizeof( ptp_device ), "%s%d", PTP_DEVICE, phc_index );
 	GPTP_LOG_ERROR("Using clock device: %s", ptp_device);
 	phc_fd = open( ptp_device, O_RDWR );
 	if( phc_fd == -1 || (_private->clockid = FD_TO_CLOCKID(phc_fd)) == -1 ) {


### PR DESCRIPTION
## Summary
- remove use of `PTP_DEVICE_IDX_OFFS`
- construct PTP device path dynamically

## Testing
- `make clean all`

------
https://chatgpt.com/codex/tasks/task_e_6851877ea2388322887a25fe289b9871