### PR TITLE
Fix log buffer sizing

### DIFF
--- a/common/gptp_log.cpp
+++ b/common/gptp_log.cpp
@@ -57,9 +57,9 @@ void gptpLog(GPTP_LOG_LEVEL level, const char *tag, const char *path, int line, 
 {
 	char msg[1024];
 
-	va_list args;
-	va_start(args, fmt);
-	vsprintf(msg, fmt, args);
+       va_list args;
+       va_start(args, fmt);
+       vsnprintf(msg, sizeof(msg), fmt, args);
 
 #ifndef GENIVI_DLT
 	std::chrono::system_clock::time_point cNow = std::chrono::system_clock::now();

--- a/windows/daemon_cl/packet.cpp
+++ b/windows/daemon_cl/packet.cpp
@@ -154,7 +154,9 @@ packet_error_t packetBind( struct packet_handle *handle, uint16_t ethertype ) {
     packet_error_t ret = PACKET_NO_ERROR;
     char filter_expression[32] = "ether proto 0x";
 
-    sprintf_s( filter_expression+strlen(filter_expression), 31-strlen(filter_expression), "%hx", ethertype );
+    snprintf( filter_expression + strlen(filter_expression),
+              sizeof(filter_expression) - strlen(filter_expression),
+              "%hx", ethertype );
     if( pcap_compile( handle->iface, &handle->filter, filter_expression, 1, 0 ) == -1 ) {
         ret = PACKET_BIND_ERROR;
         goto fnexit;


### PR DESCRIPTION
## Summary
- eliminate sprintf usage in gptp logging
- remove sprintf_s in packet.cpp

## Testing
- `./travis.sh`

------
https://chatgpt.com/codex/tasks/task_e_6852765eec988322bd500d1d9f8f034f