### PR TITLE
Fix timer param types

### DIFF
--- a/common/common_port.cpp
+++ b/common/common_port.cpp
@@ -389,7 +389,7 @@ bool CommonPort::restoreSerializedState
 }
 
 void CommonPort::startSyncReceiptTimer
-( long long unsigned int waitTime )
+( uint64_t waitTime )
 {
 	clock->getTimerQLock();
 	syncReceiptTimerLock->lock();
@@ -410,7 +410,7 @@ void CommonPort::stopSyncReceiptTimer( void )
 }
 
 void CommonPort::startSyncIntervalTimer
-( long long unsigned int waitTime )
+( uint64_t waitTime )
 {
 	if( syncIntervalTimerLock->trylock() == oslock_fail ) return;
 	clock->deleteEventTimerLocked(this, SYNC_INTERVAL_TIMEOUT_EXPIRES);
@@ -420,7 +420,7 @@ void CommonPort::startSyncIntervalTimer
 }
 
 void CommonPort::startAnnounceIntervalTimer
-( long long unsigned int waitTime )
+( uint64_t waitTime )
 {
 	announceIntervalTimerLock->lock();
 	clock->deleteEventTimerLocked


### PR DESCRIPTION
## Summary
- change timer helper function parameters from `unsigned long long` to `uint64_t`
- verify compilation

## Testing
- `g++ -std=c++14 -Icommon -Ilinux/src -c common/common_port.cpp -o /tmp/common_port.o`

------
https://chatgpt.com/codex/tasks/task_e_68663714bb0c8322aebf434caffb30bc