### PR TITLE
Update pdelay timer API types

### DIFF
--- a/common/ether_port.cpp
+++ b/common/ether_port.cpp
@@ -881,12 +881,11 @@ bool EtherPort::_processEvent( Event e )
 			putTxLock();
 
 			{
-				long long timeout;
-				long long interval;
+                               uint64_t timeout;
+                               uint64_t interval;
 
-				timeout = PDELAY_RESP_RECEIPT_TIMEOUT_MULTIPLIER *
-					((long long)
-					 (pow((double)2,getPDelayInterval())*1000000000.0));
+                                timeout = PDELAY_RESP_RECEIPT_TIMEOUT_MULTIPLIER *
+                                        static_cast<uint64_t>(pow((double)2,getPDelayInterval())*1000000000.0);
 
 				timeout = timeout > EVENT_TIMER_GRANULARITY ?
 					timeout : EVENT_TIMER_GRANULARITY;
@@ -896,9 +895,8 @@ bool EtherPort::_processEvent( Event e )
 					"PDelay interval %d, timeout %lld",
 					getPDelayInterval(), timeout);
 
-				interval =
-					((long long)
-					 (pow((double)2,getPDelayInterval())*1000000000.0));
+                                interval =
+                                        static_cast<uint64_t>(pow((double)2,getPDelayInterval())*1000000000.0);
 				interval = interval > EVENT_TIMER_GRANULARITY ?
 					interval : EVENT_TIMER_GRANULARITY;
 				GPTP_LOG_DEBUG("Restarting PDelay timer with interval=%lld ns (%.3f ms) ***", 
@@ -1261,8 +1259,7 @@ int EtherPort::getRxTimestamp
 	return 0;
 }
 
-void EtherPort::startPDelayIntervalTimer
-( long long unsigned int waitTime )
+void EtherPort::startPDelayIntervalTimer(uint64_t waitTime)
 {
 	GPTP_LOG_DEBUG("startPDelayIntervalTimer() called with waitTime=%llu ns (%.3f ms) ***", 
 		waitTime, waitTime / 1000000.0);

--- a/common/ether_port.hpp
+++ b/common/ether_port.hpp
@@ -305,7 +305,7 @@ protected:
 	 * @param  waitTime time interval
 	 * @return none
 	 */
-	void startPDelayIntervalTimer(long long unsigned int waitTime);
+       void startPDelayIntervalTimer(uint64_t waitTime);
 
 	/**
 	 * @brief  Increments PDelay sequence ID and returns.

--- a/common/ptp_message.cpp
+++ b/common/ptp_message.cpp
@@ -2070,7 +2070,7 @@ bool PTPMessageSignalling::sendPort
 
 void PTPMessageSignalling::processMessage( CommonPort *port )
 {
-	long long unsigned int waitTime;
+       uint64_t waitTime;
 
 	GPTP_LOG_STATUS("Signalling Link Delay Interval: %d", tlv.getLinkDelayInterval());
 	GPTP_LOG_STATUS("Signalling Sync Interval: %d", tlv.getTimeSyncInterval());
@@ -2083,7 +2083,7 @@ void PTPMessageSignalling::processMessage( CommonPort *port )
 	if (linkDelayInterval == PTPMessageSignalling::sigMsgInterval_Initial) {
 		port->resetInitPDelayInterval();
 
-		waitTime = ((long long) (pow(2.0, port->getPDelayInterval()) *  1000000000.0));
+               waitTime = static_cast<uint64_t>(pow(2.0, port->getPDelayInterval()) *  1000000000.0);
 		waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 		port->startPDelayIntervalTimer(waitTime);
 	}
@@ -2097,7 +2097,7 @@ void PTPMessageSignalling::processMessage( CommonPort *port )
 	else {
 		port->setPDelayInterval(linkDelayInterval);
 
-		waitTime = ((long long) (pow(2.0, port->getPDelayInterval()) *  1000000000.0));
+               waitTime = static_cast<uint64_t>(pow(2.0, port->getPDelayInterval()) *  1000000000.0);
 		waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 		port->startPDelayIntervalTimer(waitTime);
 	}
@@ -2105,7 +2105,7 @@ void PTPMessageSignalling::processMessage( CommonPort *port )
 	if (timeSyncInterval == PTPMessageSignalling::sigMsgInterval_Initial) {
 		port->resetInitSyncInterval();
 
-		waitTime = ((long long) (pow((double)2, port->getSyncInterval()) *  1000000000.0));
+               waitTime = static_cast<uint64_t>(pow((double)2, port->getSyncInterval()) *  1000000000.0);
 		waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 		port->startSyncIntervalTimer(waitTime);
 	}
@@ -2119,7 +2119,7 @@ void PTPMessageSignalling::processMessage( CommonPort *port )
 	else {
 		port->setSyncInterval(timeSyncInterval);
 
-		waitTime = ((long long) (pow((double)2, port->getSyncInterval()) *  1000000000.0));
+               waitTime = static_cast<uint64_t>(pow((double)2, port->getSyncInterval()) *  1000000000.0);
 		waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 		port->startSyncIntervalTimer(waitTime);
 	}
@@ -2131,7 +2131,7 @@ void PTPMessageSignalling::processMessage( CommonPort *port )
 			int8_t initial_interval = port->getProfileAnnounceInterval();
 			port->setAnnounceInterval(initial_interval);
 			
-			waitTime = ((long long) (pow((double)2, port->getAnnounceInterval()) *  1000000000.0));
+                       waitTime = static_cast<uint64_t>(pow((double)2, port->getAnnounceInterval()) *  1000000000.0);
 			waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 			port->startAnnounceIntervalTimer(waitTime);
 			
@@ -2149,7 +2149,7 @@ void PTPMessageSignalling::processMessage( CommonPort *port )
 		else {
 			port->setAnnounceInterval(announceInterval);
 
-			waitTime = ((long long) (pow((double)2, port->getAnnounceInterval()) *  1000000000.0));
+                       waitTime = static_cast<uint64_t>(pow((double)2, port->getAnnounceInterval()) *  1000000000.0);
 			waitTime = waitTime > EVENT_TIMER_GRANULARITY ? waitTime : EVENT_TIMER_GRANULARITY;
 			port->startAnnounceIntervalTimer(waitTime);
 		}


### PR DESCRIPTION
## Summary
- use `uint64_t` for pDelay interval timer values
- update signalling logic and EtherPort implementation to match

## Testing
- `make -C linux/build clean all` *(fails: GetCurrentThreadId not declared)*

------
https://chatgpt.com/codex/tasks/task_e_68663b350f188322b54d86195a344196